### PR TITLE
Fix many-to-many insert

### DIFF
--- a/lib/change.subscriber.ts
+++ b/lib/change.subscriber.ts
@@ -23,7 +23,8 @@ export class ChangeSubscriber implements EntitySubscriberInterface<any> {
     if (ChangeSubscriber.disabled)
       return;
 
-    if (Reflect.hasMetadata("__track_changes", event.entity.constructor)) {
+    if (event.entity &&
+				Reflect.hasMetadata("__track_changes", event.entity.constructor)) {
       await event.connection.getCustomRepository(ChangeRepository).createChangeEntry(event.entity, ChangeAction.CREATE);
     }
   }

--- a/lib/spec/factories.ts
+++ b/lib/spec/factories.ts
@@ -1,8 +1,15 @@
 import { Factory, Sequence } from '@linnify/typeorm-factory';
 import { Tracked } from './test-app/tracked.entity';
+import { UnTracked } from './test-app/untracked.entity';
 
 export class TrackedFactory extends Factory<Tracked> {
 	entity = Tracked;
 
 	name = new Sequence((i: number) => `Name ${i}`)
+}
+
+export class UnTrackedFactory extends Factory<UnTracked> {
+	entity = UnTracked;
+
+	name = new Sequence((i: number) => `Entity ${++i} (untracked)`);
 }

--- a/lib/spec/factories.ts
+++ b/lib/spec/factories.ts
@@ -1,4 +1,5 @@
 import { Factory, Sequence } from '@linnify/typeorm-factory';
+import { RelatedThingy } from './test-app/related.entity';
 import { Tracked } from './test-app/tracked.entity';
 import { UnTracked } from './test-app/untracked.entity';
 
@@ -12,4 +13,8 @@ export class UnTrackedFactory extends Factory<UnTracked> {
 	entity = UnTracked;
 
 	name = new Sequence((i: number) => `Entity ${++i} (untracked)`);
+}
+
+export class RelatedFactory extends Factory<RelatedThingy> {
+	entity = RelatedThingy;
 }

--- a/lib/spec/test-app/app.module.ts
+++ b/lib/spec/test-app/app.module.ts
@@ -4,6 +4,7 @@ import { addChangeDetectionToConnection } from "../..";
 import { ChangeModule } from "../../change.module";
 import { RelatedThingy } from "./related.entity";
 import { Tracked } from "./tracked.entity";
+import { UnTracked } from "./untracked.entity";
 
 @Module({
   imports: [
@@ -12,7 +13,7 @@ import { Tracked } from "./tracked.entity";
       username: process.env.DB_USER || undefined,
       host: 'localhost',
       database: 'nestjs-changelog-tests',
-      entities: [Tracked, RelatedThingy],
+      entities: [Tracked, UnTracked, RelatedThingy],
       synchronize: true,
     })),
     ChangeModule.register({

--- a/lib/spec/test-app/untracked.entity.ts
+++ b/lib/spec/test-app/untracked.entity.ts
@@ -1,0 +1,42 @@
+import {
+	BaseEntity,
+	Column,
+	DeleteDateColumn,
+	Entity,
+	JoinTable,
+	ManyToMany,
+	ManyToOne,
+	OneToMany,
+	PrimaryGeneratedColumn,
+	UpdateDateColumn,
+} from "typeorm";
+import { RelatedThingy } from "./related.entity";
+
+/** An entity that should be ignored by the change tracking system. */
+@Entity()
+export class UnTracked extends BaseEntity {
+	@PrimaryGeneratedColumn()
+	id: number;
+
+	@Column()
+	name: string;
+
+	@Column({ nullable: true })
+	ignored: string;
+
+	@ManyToOne(() => RelatedThingy, (related) => related.allTracked)
+	relatedThingy: RelatedThingy;
+
+	@OneToMany(() => RelatedThingy, (related) => related.tracked, { eager: true })
+	relatedThingies: RelatedThingy[];
+
+	@ManyToMany(() => RelatedThingy, { eager: true })
+	@JoinTable()
+	manyRelatedThingies: RelatedThingy[];
+
+	@DeleteDateColumn()
+	deletedAt: Date;
+
+	@UpdateDateColumn()
+	updatedAt: Date;
+}


### PR DESCRIPTION
## Changes

- Modified `ChangeSubscriber` to check whether an entity is being inserted.
- Added unit test (and related items) for the fix.

## Purpose

Closes #6, allowing consumers to save many-to-many relations.